### PR TITLE
Cleanup

### DIFF
--- a/main/tm/Direction.java
+++ b/main/tm/Direction.java
@@ -1,0 +1,11 @@
+package tm;
+
+/**
+ * Represents the possible movement directions of a
+ * Turing Machine's read/write head.
+ *
+ * @author Jayce Lowry
+ */
+public enum Direction {
+    LEFT, RIGHT
+}

--- a/main/tm/TMInterface.java
+++ b/main/tm/TMInterface.java
@@ -11,12 +11,6 @@ import java.util.Set;
 public interface TMInterface {
 
     /**
-     * Enum representing possible movement directions for the
-     * read/write head.
-     */
-    enum Direction {LEFT, RIGHT}
-
-    /**
      * Runs a simulation of this Turing Machine with a given
      * String input.
      *

--- a/main/tm/TMInterface.java
+++ b/main/tm/TMInterface.java
@@ -14,7 +14,7 @@ public interface TMInterface {
      * Enum representing possible movement directions for the
      * read/write head.
      */
-    public enum Direction {LEFT, RIGHT};
+    enum Direction {LEFT, RIGHT}
 
     /**
      * Runs a simulation of this Turing Machine with a given
@@ -24,7 +24,7 @@ public interface TMInterface {
      * @return a string containing the contents of the tape
      * cells visited during the simulation.
      */
-    public String run(String inputString);
+    String run(String inputString);
 
     /**
      * Adds a new state with a given name
@@ -34,7 +34,7 @@ public interface TMInterface {
      * @return true if the new state was added, false if
      * the state already exists.
      */
-    public boolean addState(String name);
+    boolean addState(String name);
 
     /**
      * Adds a transition between two states in this
@@ -50,7 +50,7 @@ public interface TMInterface {
      * @return true if successful, false if the states don't exist or if
      * the read or write symbols are not in the tape alphabet.
      */
-    public boolean addTransition(String fromState, String toState, char readSymb, char writeSymb, Direction move);
+    boolean addTransition(String fromState, String toState, char readSymb, char writeSymb, Direction move);
 
     /**
      * Marks a state with a given name as the initial state.
@@ -59,7 +59,7 @@ public interface TMInterface {
      * @return true if successful, false if a state with the
      * given name does not exist.
      */
-    public boolean setStart(String name);
+    boolean setStart(String name);
 
     /**
      * Marks a state with a given name as the accepting state.
@@ -68,7 +68,7 @@ public interface TMInterface {
      * @return true if successful, false if a state with the
      * given name does not exist.
      */
-    public boolean setFinal(String name);
+    boolean setFinal(String name);
 
     /**
      * Determines if a state with the given name is an initial
@@ -78,7 +78,7 @@ public interface TMInterface {
      * @return true if a state with the given
      * name exists and is the initial state.
      */
-    public boolean isStart(String name);
+    boolean isStart(String name);
 
     /**
      * Determines if a state with the given name is the final
@@ -88,7 +88,7 @@ public interface TMInterface {
      * @return true if a state with the given
      * name exists and is the final state.
      */
-    public boolean isFinal(String name);
+    boolean isFinal(String name);
 
     /**
      * Adds a symbol to the alphabet. The symbol
@@ -98,14 +98,14 @@ public interface TMInterface {
      * @param symbol the symbol to add to the
      * alphabet.
      */
-    public void addSigma(char symbol);
+    void addSigma(char symbol);
 
     /**
      * Gets the alphabet for this Turing Machine.
      *
      * @return the alphabet of this Turing Machine.
      */
-    public Set<Character> getSigma();
+    Set<Character> getSigma();
 
     /**
      * Returns state with the given name, or null if
@@ -115,5 +115,5 @@ public interface TMInterface {
      * @return TMState object or null if the state
      * doesn't exist.
      */
-    public TMState getState(String name);
+    TMState getState(String name);
 }

--- a/main/tm/TMParser.java
+++ b/main/tm/TMParser.java
@@ -58,8 +58,8 @@ public class TMParser implements TMParserInterface {
             String from = String.valueOf(fromStateIndex);
             String to = stringParts[0];
             char write = stringParts[1].charAt(0);
-            TMInterface.Direction direction = stringParts[2].equals("L")
-                    ? TMInterface.Direction.LEFT : TMInterface.Direction.RIGHT;
+            Direction direction = stringParts[2].equals("L")
+                    ? Direction.LEFT : Direction.RIGHT;
             char read = (char)(readSymbolIndex + '0');
 
             machine.addTransition(from, to, read, write, direction);

--- a/main/tm/TMParserInterface.java
+++ b/main/tm/TMParserInterface.java
@@ -30,12 +30,12 @@ public interface TMParserInterface {
      * @return an instance of the Turing Machine, constructed
      * from a parsed file.
      */
-    public TMInterface getMachine();
+    TMInterface getMachine();
 
     /**
      * Gets the input string processed by this parser.
      *
      * @return the input string.
      */
-    public String getInputString();
+    String getInputString();
 }

--- a/main/tm/TMState.java
+++ b/main/tm/TMState.java
@@ -39,7 +39,7 @@ public class TMState {
      * @param writeSymb the symbol to write to the tape.
      * @param move the direction to move on the tape.
      */
-    public void setTransition(TMState toState, char readSymb, char writeSymb, TMInterface.Direction move) {
+    public void setTransition(TMState toState, char readSymb, char writeSymb, Direction move) {
         if (toState == null) {
             return;
         }
@@ -81,7 +81,7 @@ public class TMState {
      * @return the direction to move, or null if no transition
      * on the given symbol exists.
      */
-    public TMInterface.Direction getMoveDirection(char readSymb) {
+    public Direction getMoveDirection(char readSymb) {
         TMTransition transitionData = transitions.get(readSymb);
         return (transitionData == null) ? null : transitionData.getDirection();
     }
@@ -96,7 +96,7 @@ public class TMState {
     private class TMTransition {
         private final TMState nextState;
         private final char writeSymbol;
-        private final TMInterface.Direction direction;
+        private final Direction direction;
 
         /**
          * Creates a new TMTransition
@@ -105,7 +105,7 @@ public class TMState {
          * @param writeSymbol the symbol to write to the tape.
          * @param direction the direction to move on the tape.
          */
-        private TMTransition(TMState nextState, char writeSymbol, TMInterface.Direction direction) {
+        private TMTransition(TMState nextState, char writeSymbol, Direction direction) {
             this.nextState = nextState;
             this.writeSymbol = writeSymbol;
             this.direction = direction;
@@ -128,7 +128,7 @@ public class TMState {
         /**
          * @return the direction to move on the tape.
          */
-        private TMInterface.Direction getDirection() {
+        private Direction getDirection() {
             return direction;
         }
     }

--- a/main/tm/TMTape.java
+++ b/main/tm/TMTape.java
@@ -63,11 +63,11 @@ public class TMTape implements TMTapeInterface {
      * {@inheritDoc}
      */
     @Override
-    public void move(TMInterface.Direction direction) {
+    public void move(Direction direction) {
         if (direction == null) {
             return;
         }
-        if (direction == TMInterface.Direction.LEFT) {
+        if (direction == Direction.LEFT) {
             head--;
         } else { 
             head++;

--- a/main/tm/TMTapeInterface.java
+++ b/main/tm/TMTapeInterface.java
@@ -16,7 +16,7 @@ public interface TMTapeInterface {
      * @return the character in the current
      * tape cell.
      */
-    public char read();
+    char read();
 
     /**
      * Writes a given symbol to the current
@@ -24,7 +24,7 @@ public interface TMTapeInterface {
      *
      * @param symbol the character to write.
      */
-    public void write(Character symbol);
+    void write(Character symbol);
 
     /**
      * Moves the read/write head for this tape
@@ -33,7 +33,7 @@ public interface TMTapeInterface {
      * @param direction the direction to move, which
      * is either left or right.
      */
-    public void move(TMInterface.Direction direction);
+    void move(TMInterface.Direction direction);
 
     /**
      * Gets the contents of visited tape cells, starting
@@ -43,5 +43,5 @@ public interface TMTapeInterface {
      * @return a String containing the contents of cells
      * that have been visited by the read/write head.
      */
-    public String getVisited();
+    String getVisited();
 }

--- a/main/tm/TMTapeInterface.java
+++ b/main/tm/TMTapeInterface.java
@@ -33,7 +33,7 @@ public interface TMTapeInterface {
      * @param direction the direction to move, which
      * is either left or right.
      */
-    void move(TMInterface.Direction direction);
+    void move(Direction direction);
 
     /**
      * Gets the contents of visited tape cells, starting

--- a/test/tm/TMParserTest.java
+++ b/test/tm/TMParserTest.java
@@ -36,29 +36,29 @@ public class TMParserTest {
         // State 0, read '0'
         assertEquals(state1, state0.getTransitionState('0'));
         assertEquals(Character.valueOf('1'), state0.getWriteSymbol('0'));
-        assertEquals(TMInterface.Direction.RIGHT, state0.getMoveDirection('0'));
+        assertEquals(Direction.RIGHT, state0.getMoveDirection('0'));
         // State 0, read '1'
         assertEquals(state2, state0.getTransitionState('1'));
         assertEquals(Character.valueOf('1'), state0.getWriteSymbol('1'));
-        assertEquals(TMInterface.Direction.LEFT, state0.getMoveDirection('1'));
+        assertEquals(Direction.LEFT, state0.getMoveDirection('1'));
 
         // State 1, read '0'
         assertEquals(state0, state1.getTransitionState('0'));
         assertEquals(Character.valueOf('1'), state1.getWriteSymbol('0'));
-        assertEquals(TMInterface.Direction.LEFT, state1.getMoveDirection('0'));
+        assertEquals(Direction.LEFT, state1.getMoveDirection('0'));
         // State 1, read '1'
         assertEquals(state1, state1.getTransitionState('1'));
         assertEquals(Character.valueOf('1'), state1.getWriteSymbol('1'));
-        assertEquals(TMInterface.Direction.RIGHT, state1.getMoveDirection('1'));
+        assertEquals(Direction.RIGHT, state1.getMoveDirection('1'));
 
         // State 2, read '0'
         assertEquals(state1, state2.getTransitionState('0'));
         assertEquals(Character.valueOf('1'), state2.getWriteSymbol('0'));
-        assertEquals(TMInterface.Direction.LEFT, state2.getMoveDirection('0'));
+        assertEquals(Direction.LEFT, state2.getMoveDirection('0'));
         // State 2, read '1'
         assertEquals(state3, state2.getTransitionState('1'));
         assertEquals(Character.valueOf('1'), state2.getWriteSymbol('1'));
-        assertEquals(TMInterface.Direction.RIGHT, state2.getMoveDirection('1'));
+        assertEquals(Direction.RIGHT, state2.getMoveDirection('1'));
 
         // State 3, read '0'
         assertNull(state3.getTransitionState('0'));
@@ -98,70 +98,70 @@ public class TMParserTest {
         // State 0, read '0'
         assertEquals(state2, state0.getTransitionState('0'));
         assertEquals(Character.valueOf('1'), state0.getWriteSymbol('0'));
-        assertEquals(TMInterface.Direction.LEFT, state0.getMoveDirection('0'));
+        assertEquals(Direction.LEFT, state0.getMoveDirection('0'));
         // State 0, read '1'
         assertEquals(state4, state0.getTransitionState('1'));
         assertEquals(Character.valueOf('2'), state0.getWriteSymbol('1'));
-        assertEquals(TMInterface.Direction.LEFT, state0.getMoveDirection('1'));
+        assertEquals(Direction.LEFT, state0.getMoveDirection('1'));
         // State 0, read '2'
         assertEquals(state1, state0.getTransitionState('2'));
         assertEquals(Character.valueOf('0'), state0.getWriteSymbol('2'));
-        assertEquals(TMInterface.Direction.LEFT, state0.getMoveDirection('2'));
+        assertEquals(Direction.LEFT, state0.getMoveDirection('2'));
         // State 0, read '3'
         assertEquals(state3, state0.getTransitionState('3'));
         assertEquals(Character.valueOf('0'), state0.getWriteSymbol('3'));
-        assertEquals(TMInterface.Direction.LEFT, state0.getMoveDirection('3'));
+        assertEquals(Direction.LEFT, state0.getMoveDirection('3'));
 
         // State 1, read '0'
         assertEquals(state3, state1.getTransitionState('0'));
         assertEquals(Character.valueOf('3'), state1.getWriteSymbol('0'));
-        assertEquals(TMInterface.Direction.RIGHT, state1.getMoveDirection('0'));
+        assertEquals(Direction.RIGHT, state1.getMoveDirection('0'));
         // State 1, read '1'
         assertEquals(state3, state1.getTransitionState('1'));
         assertEquals(Character.valueOf('3'), state1.getWriteSymbol('1'));
-        assertEquals(TMInterface.Direction.LEFT, state1.getMoveDirection('1'));
+        assertEquals(Direction.LEFT, state1.getMoveDirection('1'));
         // State 1, read '2'
         assertEquals(state3, state1.getTransitionState('2'));
         assertEquals(Character.valueOf('3'), state1.getWriteSymbol('2'));
-        assertEquals(TMInterface.Direction.LEFT, state1.getMoveDirection('2'));
+        assertEquals(Direction.LEFT, state1.getMoveDirection('2'));
         // State 1, read '3'
         assertEquals(state1, state1.getTransitionState('3'));
         assertEquals(Character.valueOf('1'), state1.getWriteSymbol('3'));
-        assertEquals(TMInterface.Direction.RIGHT, state1.getMoveDirection('3'));
+        assertEquals(Direction.RIGHT, state1.getMoveDirection('3'));
 
         // State 2, read '0'
         assertEquals(state1, state2.getTransitionState('0'));
         assertEquals(Character.valueOf('3'), state2.getWriteSymbol('0'));
-        assertEquals(TMInterface.Direction.LEFT, state2.getMoveDirection('0'));
+        assertEquals(Direction.LEFT, state2.getMoveDirection('0'));
         // State 2, read '1'
         assertEquals(state2, state2.getTransitionState('1'));
         assertEquals(Character.valueOf('3'), state2.getWriteSymbol('1'));
-        assertEquals(TMInterface.Direction.LEFT, state2.getMoveDirection('1'));
+        assertEquals(Direction.LEFT, state2.getMoveDirection('1'));
         // State 2, read '2'
         assertEquals(state0, state2.getTransitionState('2'));
         assertEquals(Character.valueOf('1'), state2.getWriteSymbol('2'));
-        assertEquals(TMInterface.Direction.RIGHT, state2.getMoveDirection('2'));
+        assertEquals(Direction.RIGHT, state2.getMoveDirection('2'));
         // State 2, read '3'
         assertEquals(state2, state2.getTransitionState('3'));
         assertEquals(Character.valueOf('1'), state2.getWriteSymbol('3'));
-        assertEquals(TMInterface.Direction.RIGHT, state2.getMoveDirection('3'));
+        assertEquals(Direction.RIGHT, state2.getMoveDirection('3'));
 
         // State 3, read '0'
         assertEquals(state0, state3.getTransitionState('0'));
         assertEquals(Character.valueOf('1'), state3.getWriteSymbol('0'));
-        assertEquals(TMInterface.Direction.RIGHT, state3.getMoveDirection('0'));
+        assertEquals(Direction.RIGHT, state3.getMoveDirection('0'));
         // State 3, read '1'
         assertEquals(state1, state3.getTransitionState('1'));
         assertEquals(Character.valueOf('0'), state3.getWriteSymbol('1'));
-        assertEquals(TMInterface.Direction.RIGHT, state3.getMoveDirection('1'));
+        assertEquals(Direction.RIGHT, state3.getMoveDirection('1'));
         // State 3, read '2'
         assertEquals(state0, state3.getTransitionState('2'));
         assertEquals(Character.valueOf('2'), state3.getWriteSymbol('2'));
-        assertEquals(TMInterface.Direction.RIGHT, state3.getMoveDirection('2'));
+        assertEquals(Direction.RIGHT, state3.getMoveDirection('2'));
         // State 3, read '3'
         assertEquals(state2, state3.getTransitionState('3'));
         assertEquals(Character.valueOf('2'), state3.getWriteSymbol('3'));
-        assertEquals(TMInterface.Direction.RIGHT, state3.getMoveDirection('3'));
+        assertEquals(Direction.RIGHT, state3.getMoveDirection('3'));
 
         // State 4, read '0'
         assertNull(state4.getTransitionState('0'));
@@ -207,53 +207,53 @@ public class TMParserTest {
         // State 0, read '0'
         assertEquals(state1, state0.getTransitionState('0'));
         assertEquals(Character.valueOf('3'), state0.getWriteSymbol('0'));
-        assertEquals(TMInterface.Direction.RIGHT, state0.getMoveDirection('0'));
+        assertEquals(Direction.RIGHT, state0.getMoveDirection('0'));
         // State 0, read '1'
         assertEquals(state0, state0.getTransitionState('1'));
         assertEquals(Character.valueOf('0'), state0.getWriteSymbol('1'));
-        assertEquals(TMInterface.Direction.RIGHT, state0.getMoveDirection('1'));
+        assertEquals(Direction.RIGHT, state0.getMoveDirection('1'));
         // State 0, read '2'
         assertEquals(state2, state0.getTransitionState('2'));
         assertEquals(Character.valueOf('0'), state0.getWriteSymbol('2'));
-        assertEquals(TMInterface.Direction.LEFT, state0.getMoveDirection('2'));
+        assertEquals(Direction.LEFT, state0.getMoveDirection('2'));
         // State 0, read '3'
         assertEquals(state2, state0.getTransitionState('3'));
         assertEquals(Character.valueOf('2'), state0.getWriteSymbol('3'));
-        assertEquals(TMInterface.Direction.LEFT, state0.getMoveDirection('3'));
+        assertEquals(Direction.LEFT, state0.getMoveDirection('3'));
 
         // State 1, read '0'
         assertEquals(state2, state1.getTransitionState('0'));
         assertEquals(Character.valueOf('1'), state1.getWriteSymbol('0'));
-        assertEquals(TMInterface.Direction.LEFT, state1.getMoveDirection('0'));
+        assertEquals(Direction.LEFT, state1.getMoveDirection('0'));
         // State 1, read '1'
         assertEquals(state2, state1.getTransitionState('1'));
         assertEquals(Character.valueOf('0'), state1.getWriteSymbol('1'));
-        assertEquals(TMInterface.Direction.RIGHT, state1.getMoveDirection('1'));
+        assertEquals(Direction.RIGHT, state1.getMoveDirection('1'));
         // State 1, read '2'
         assertEquals(state1, state1.getTransitionState('2'));
         assertEquals(Character.valueOf('3'), state1.getWriteSymbol('2'));
-        assertEquals(TMInterface.Direction.LEFT, state1.getMoveDirection('2'));
+        assertEquals(Direction.LEFT, state1.getMoveDirection('2'));
         // State 1, read '3'
         assertEquals(state2, state1.getTransitionState('3'));
         assertEquals(Character.valueOf('2'), state1.getWriteSymbol('3'));
-        assertEquals(TMInterface.Direction.RIGHT, state1.getMoveDirection('3'));
+        assertEquals(Direction.RIGHT, state1.getMoveDirection('3'));
 
         // State 2, read '0'
         assertEquals(state0, state2.getTransitionState('0'));
         assertEquals(Character.valueOf('3'), state2.getWriteSymbol('0'));
-        assertEquals(TMInterface.Direction.RIGHT, state2.getMoveDirection('0'));
+        assertEquals(Direction.RIGHT, state2.getMoveDirection('0'));
         // State 2, read '1'
         assertEquals(state1, state2.getTransitionState('1'));
         assertEquals(Character.valueOf('0'), state2.getWriteSymbol('1'));
-        assertEquals(TMInterface.Direction.RIGHT, state2.getMoveDirection('1'));
+        assertEquals(Direction.RIGHT, state2.getMoveDirection('1'));
         // State 2, read '2'
         assertEquals(state3, state2.getTransitionState('2'));
         assertEquals(Character.valueOf('3'), state2.getWriteSymbol('2'));
-        assertEquals(TMInterface.Direction.RIGHT, state2.getMoveDirection('2'));
+        assertEquals(Direction.RIGHT, state2.getMoveDirection('2'));
         // State 2, read '3'
         assertEquals(state1, state2.getTransitionState('3'));
         assertEquals(Character.valueOf('0'), state2.getWriteSymbol('3'));
-        assertEquals(TMInterface.Direction.LEFT, state2.getMoveDirection('3'));
+        assertEquals(Direction.LEFT, state2.getMoveDirection('3'));
 
         // State 4, read '0'
         assertNull(state3.getTransitionState('0'));

--- a/test/tm/TMTapeTest.java
+++ b/test/tm/TMTapeTest.java
@@ -20,15 +20,15 @@ public class TMTapeTest {
     @Test
     public void testEmpty_Move() {
         TMTape tape = new TMTape("");
-        tape.move(TMInterface.Direction.LEFT);
+        tape.move(Direction.LEFT);
         assertEquals('0', tape.read());
         assertEquals("00", tape.getVisited());
 
-        tape.move(TMInterface.Direction.RIGHT);
+        tape.move(Direction.RIGHT);
         assertEquals('0', tape.read());
         assertEquals("00", tape.getVisited());
 
-        tape.move(TMInterface.Direction.RIGHT);
+        tape.move(Direction.RIGHT);
         assertEquals('0', tape.read());
         assertEquals("000", tape.getVisited());
     }
@@ -45,16 +45,16 @@ public class TMTapeTest {
     public void testEmpty_WriteMove() {
         TMTape tape = new TMTape("");
         tape.write('1');
-        tape.move(TMInterface.Direction.LEFT);
+        tape.move(Direction.LEFT);
 
         assertEquals('0', tape.read());
         assertEquals("01", tape.getVisited());
 
-        tape.move(TMInterface.Direction.RIGHT);
+        tape.move(Direction.RIGHT);
         assertEquals('1', tape.read());
         assertEquals("01", tape.getVisited());
 
-        tape.move(TMInterface.Direction.RIGHT);
+        tape.move(Direction.RIGHT);
         assertEquals('0', tape.read());
         assertEquals("010", tape.getVisited());
     }
@@ -62,27 +62,27 @@ public class TMTapeTest {
     @Test
     public void testEmpty_MoveWrite() {
         TMTape tape = new TMTape("");
-        tape.move(TMInterface.Direction.RIGHT);
+        tape.move(Direction.RIGHT);
         tape.write('1');
 
         assertEquals('1', tape.read());
         assertEquals("01", tape.getVisited());
 
-        tape.move(TMInterface.Direction.LEFT);
+        tape.move(Direction.LEFT);
         assertEquals('0', tape.read());
         tape.write('1');
 
         assertEquals('1', tape.read());
         assertEquals("11", tape.getVisited());
 
-        tape.move(TMInterface.Direction.LEFT);
+        tape.move(Direction.LEFT);
         assertEquals('0', tape.read());
         tape.write('1');
 
         assertEquals('1', tape.read());
         assertEquals("111", tape.getVisited());
 
-        tape.move(TMInterface.Direction.RIGHT);
+        tape.move(Direction.RIGHT);
         assertEquals('1', tape.read());
         tape.write('0');
         assertEquals('0', tape.read());
@@ -95,7 +95,7 @@ public class TMTapeTest {
         int numTimes = 50;
 
         for (int i = 0; i < numTimes; i++) {
-            tape.move(TMInterface.Direction.LEFT);
+            tape.move(Direction.LEFT);
         }
 
         assertEquals('0', tape.read());
@@ -108,7 +108,7 @@ public class TMTapeTest {
         int numTimes = 50;
 
         for (int i = 0; i < numTimes; i++) {
-            tape.move(TMInterface.Direction.RIGHT);
+            tape.move(Direction.RIGHT);
         }
 
         assertEquals('0', tape.read());
@@ -125,16 +125,16 @@ public class TMTapeTest {
     @Test
     public void test1_Move() {
         TMTape tape = new TMTape("1");
-        tape.move(TMInterface.Direction.RIGHT);
+        tape.move(Direction.RIGHT);
 
         assertEquals('0', tape.read());
         assertEquals("10", tape.getVisited());
 
-        tape.move(TMInterface.Direction.LEFT);
+        tape.move(Direction.LEFT);
         assertEquals('1', tape.read());
         assertEquals("10", tape.getVisited());
 
-        tape.move(TMInterface.Direction.LEFT);
+        tape.move(Direction.LEFT);
         assertEquals('0', tape.read());
         assertEquals("010", tape.getVisited());
     }
@@ -151,16 +151,16 @@ public class TMTapeTest {
     public void test1_WriteMove() {
         TMTape tape = new TMTape("1");
         tape.write('0');
-        tape.move(TMInterface.Direction.LEFT);
+        tape.move(Direction.LEFT);
 
         assertEquals('0', tape.read());
         assertEquals("00", tape.getVisited());
 
-        tape.move(TMInterface.Direction.RIGHT);
+        tape.move(Direction.RIGHT);
         assertEquals('0', tape.read());
         assertEquals("00", tape.getVisited());
 
-        tape.move(TMInterface.Direction.RIGHT);
+        tape.move(Direction.RIGHT);
         assertEquals('0', tape.read());
         assertEquals("000", tape.getVisited());
     }
@@ -168,27 +168,27 @@ public class TMTapeTest {
     @Test
     public void test1_MoveWrite() {
         TMTape tape = new TMTape("1");
-        tape.move(TMInterface.Direction.LEFT);
+        tape.move(Direction.LEFT);
         tape.write('1');
 
         assertEquals('1', tape.read());
         assertEquals("11", tape.getVisited());
 
-        tape.move(TMInterface.Direction.LEFT);
+        tape.move(Direction.LEFT);
         assertEquals('0', tape.read());
         tape.write('1');
 
         assertEquals('1', tape.read());
         assertEquals("111", tape.getVisited());
 
-        tape.move(TMInterface.Direction.RIGHT);
+        tape.move(Direction.RIGHT);
         assertEquals('1', tape.read());
         tape.write('0');
 
         assertEquals('0', tape.read());
         assertEquals("101", tape.getVisited());
 
-        tape.move(TMInterface.Direction.RIGHT);
+        tape.move(Direction.RIGHT);
         assertEquals('1', tape.read());
         tape.write('0');
         assertEquals('0', tape.read());
@@ -201,7 +201,7 @@ public class TMTapeTest {
         int numTimes = 50;
 
         for (int i = 0; i < numTimes; i++) {
-            tape.move(TMInterface.Direction.LEFT);
+            tape.move(Direction.LEFT);
         }
 
         assertEquals('0', tape.read());
@@ -214,7 +214,7 @@ public class TMTapeTest {
         int numTimes = 50;
 
         for (int i = 0; i < numTimes; i++) {
-            tape.move(TMInterface.Direction.RIGHT);
+            tape.move(Direction.RIGHT);
         }
 
         assertEquals('0', tape.read());
@@ -231,15 +231,15 @@ public class TMTapeTest {
     @Test
     public void test2_Move() {
         TMTape tape = new TMTape("11");
-        tape.move(TMInterface.Direction.LEFT);
+        tape.move(Direction.LEFT);
         assertEquals('0', tape.read());
         assertEquals("01", tape.getVisited());
 
-        tape.move(TMInterface.Direction.RIGHT);
+        tape.move(Direction.RIGHT);
         assertEquals('1', tape.read());
         assertEquals("01", tape.getVisited());
 
-        tape.move(TMInterface.Direction.RIGHT);
+        tape.move(Direction.RIGHT);
         assertEquals('1', tape.read());
         assertEquals("011", tape.getVisited());
     }
@@ -256,16 +256,16 @@ public class TMTapeTest {
     public void test2_WriteMove() {
         TMTape tape = new TMTape("11");
         tape.write('0');
-        tape.move(TMInterface.Direction.LEFT);
+        tape.move(Direction.LEFT);
 
         assertEquals('0', tape.read());
         assertEquals("00", tape.getVisited());
 
-        tape.move(TMInterface.Direction.RIGHT);
+        tape.move(Direction.RIGHT);
         assertEquals('0', tape.read());
         assertEquals("00", tape.getVisited());
 
-        tape.move(TMInterface.Direction.RIGHT);
+        tape.move(Direction.RIGHT);
         assertEquals('1', tape.read());
         assertEquals("001", tape.getVisited());
     }
@@ -273,27 +273,27 @@ public class TMTapeTest {
     @Test
     public void test2_MoveWrite() {
         TMTape tape = new TMTape("11");
-        tape.move(TMInterface.Direction.LEFT);
+        tape.move(Direction.LEFT);
         tape.write('1');
 
         assertEquals('1', tape.read());
         assertEquals("11", tape.getVisited());
 
-        tape.move(TMInterface.Direction.LEFT);
+        tape.move(Direction.LEFT);
         assertEquals('0', tape.read());
         tape.write('1');
 
         assertEquals('1', tape.read());
         assertEquals("111", tape.getVisited());
 
-        tape.move(TMInterface.Direction.RIGHT);
+        tape.move(Direction.RIGHT);
         assertEquals('1', tape.read());
         tape.write('0');
 
         assertEquals('0', tape.read());
         assertEquals("101", tape.getVisited());
 
-        tape.move(TMInterface.Direction.RIGHT);
+        tape.move(Direction.RIGHT);
         assertEquals('1', tape.read());
         tape.write('0');
         assertEquals('0', tape.read());
@@ -306,7 +306,7 @@ public class TMTapeTest {
         int numTimes = 50;
 
         for (int i = 0; i < numTimes; i++) {
-            tape.move(TMInterface.Direction.LEFT);
+            tape.move(Direction.LEFT);
         }
 
         assertEquals('0', tape.read());
@@ -319,7 +319,7 @@ public class TMTapeTest {
         int numTimes = 50;
 
         for (int i = 0; i < numTimes; i++) {
-            tape.move(TMInterface.Direction.RIGHT);
+            tape.move(Direction.RIGHT);
         }
 
         assertEquals('0', tape.read());

--- a/test/tm/TMTest.java
+++ b/test/tm/TMTest.java
@@ -23,12 +23,12 @@ public class TMTest {
 
         machine.addSigma('1');
 
-        assertTrue(machine.addTransition("0", "1", '0', '1', TMInterface.Direction.RIGHT));
-        assertTrue(machine.addTransition("0", "2", '1', '1', TMInterface.Direction.LEFT));
-        assertTrue(machine.addTransition("1", "0", '0', '1', TMInterface.Direction.LEFT));
-        assertTrue(machine.addTransition("1", "1", '1', '1', TMInterface.Direction.RIGHT));
-        assertTrue(machine.addTransition("2", "1", '0', '1', TMInterface.Direction.LEFT));
-        assertTrue(machine.addTransition("2", "3", '1', '1', TMInterface.Direction.RIGHT));
+        assertTrue(machine.addTransition("0", "1", '0', '1', Direction.RIGHT));
+        assertTrue(machine.addTransition("0", "2", '1', '1', Direction.LEFT));
+        assertTrue(machine.addTransition("1", "0", '0', '1', Direction.LEFT));
+        assertTrue(machine.addTransition("1", "1", '1', '1', Direction.RIGHT));
+        assertTrue(machine.addTransition("2", "1", '0', '1', Direction.LEFT));
+        assertTrue(machine.addTransition("2", "3", '1', '1', Direction.RIGHT));
 
         assertEquals("111111", machine.run(""));
     }
@@ -46,25 +46,25 @@ public class TMTest {
             machine.addSigma(Character.forDigit(i, 10));
         }
 
-        assertTrue(machine.addTransition("0", "2", '0', '1', TMInterface.Direction.LEFT));
-        assertTrue(machine.addTransition("0", "4", '1', '2', TMInterface.Direction.LEFT));
-        assertTrue(machine.addTransition("0", "1", '2', '0', TMInterface.Direction.LEFT));
-        assertTrue(machine.addTransition("0", "3", '3', '0', TMInterface.Direction.LEFT));
+        assertTrue(machine.addTransition("0", "2", '0', '1', Direction.LEFT));
+        assertTrue(machine.addTransition("0", "4", '1', '2', Direction.LEFT));
+        assertTrue(machine.addTransition("0", "1", '2', '0', Direction.LEFT));
+        assertTrue(machine.addTransition("0", "3", '3', '0', Direction.LEFT));
 
-        assertTrue(machine.addTransition("1", "3", '0', '3', TMInterface.Direction.RIGHT));
-        assertTrue(machine.addTransition("1", "3", '1', '3', TMInterface.Direction.LEFT));
-        assertTrue(machine.addTransition("1", "3", '2', '3', TMInterface.Direction.LEFT));
-        assertTrue(machine.addTransition("1", "1", '3', '1', TMInterface.Direction.RIGHT));
+        assertTrue(machine.addTransition("1", "3", '0', '3', Direction.RIGHT));
+        assertTrue(machine.addTransition("1", "3", '1', '3', Direction.LEFT));
+        assertTrue(machine.addTransition("1", "3", '2', '3', Direction.LEFT));
+        assertTrue(machine.addTransition("1", "1", '3', '1', Direction.RIGHT));
 
-        assertTrue(machine.addTransition("2", "1", '0', '3', TMInterface.Direction.LEFT));
-        assertTrue(machine.addTransition("2", "2", '1', '3', TMInterface.Direction.LEFT));
-        assertTrue(machine.addTransition("2", "0", '2', '1', TMInterface.Direction.RIGHT));
-        assertTrue(machine.addTransition("2", "2", '3', '1', TMInterface.Direction.RIGHT));
+        assertTrue(machine.addTransition("2", "1", '0', '3', Direction.LEFT));
+        assertTrue(machine.addTransition("2", "2", '1', '3', Direction.LEFT));
+        assertTrue(machine.addTransition("2", "0", '2', '1', Direction.RIGHT));
+        assertTrue(machine.addTransition("2", "2", '3', '1', Direction.RIGHT));
 
-        assertTrue(machine.addTransition("3", "0", '0', '1', TMInterface.Direction.RIGHT));
-        assertTrue(machine.addTransition("3", "1", '1', '0', TMInterface.Direction.RIGHT));
-        assertTrue(machine.addTransition("3", "0", '2', '2', TMInterface.Direction.RIGHT));
-        assertTrue(machine.addTransition("3", "2", '3', '2', TMInterface.Direction.RIGHT));
+        assertTrue(machine.addTransition("3", "0", '0', '1', Direction.RIGHT));
+        assertTrue(machine.addTransition("3", "1", '1', '0', Direction.RIGHT));
+        assertTrue(machine.addTransition("3", "0", '2', '2', Direction.RIGHT));
+        assertTrue(machine.addTransition("3", "2", '3', '2', Direction.RIGHT));
 
         String expected = "03123333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333";
 
@@ -85,20 +85,20 @@ public class TMTest {
             machine.addSigma(Character.forDigit(i, 10));
         }
 
-        machine.addTransition("0", "1", '0', '3', TMInterface.Direction.RIGHT);
-        machine.addTransition("0", "0", '1', '0', TMInterface.Direction.RIGHT);
-        machine.addTransition("0", "2", '2', '0', TMInterface.Direction.LEFT);
-        machine.addTransition("0", "2", '3', '2', TMInterface.Direction.LEFT);
+        machine.addTransition("0", "1", '0', '3', Direction.RIGHT);
+        machine.addTransition("0", "0", '1', '0', Direction.RIGHT);
+        machine.addTransition("0", "2", '2', '0', Direction.LEFT);
+        machine.addTransition("0", "2", '3', '2', Direction.LEFT);
 
-        machine.addTransition("1", "2", '0', '1', TMInterface.Direction.LEFT);
-        machine.addTransition("1", "2", '1', '0', TMInterface.Direction.RIGHT);
-        machine.addTransition("1", "1", '2', '3', TMInterface.Direction.LEFT);
-        machine.addTransition("1", "2", '3', '2', TMInterface.Direction.RIGHT);
+        machine.addTransition("1", "2", '0', '1', Direction.LEFT);
+        machine.addTransition("1", "2", '1', '0', Direction.RIGHT);
+        machine.addTransition("1", "1", '2', '3', Direction.LEFT);
+        machine.addTransition("1", "2", '3', '2', Direction.RIGHT);
 
-        machine.addTransition("2", "0", '0', '3', TMInterface.Direction.RIGHT);
-        machine.addTransition("2", "1", '1', '0', TMInterface.Direction.RIGHT);
-        machine.addTransition("2", "3", '2', '3', TMInterface.Direction.RIGHT);
-        machine.addTransition("2", "1", '3', '0', TMInterface.Direction.LEFT);
+        machine.addTransition("2", "0", '0', '3', Direction.RIGHT);
+        machine.addTransition("2", "1", '1', '0', Direction.RIGHT);
+        machine.addTransition("2", "3", '2', '3', Direction.RIGHT);
+        machine.addTransition("2", "1", '3', '0', Direction.LEFT);
 
         String out = machine.run("");
 


### PR DESCRIPTION
- Removed unnecessary visibility modifiers from interface methods
- Refactored the `Direction` enum so that it's in its own file. This makes it so that you can declare `Direction` types instead of having to specify `TMInterface.Direction`